### PR TITLE
align step for classify_wf and de_novo_wf function fixed.

### DIFF
--- a/bin/gtdbtk
+++ b/bin/gtdbtk
@@ -91,29 +91,44 @@ if __name__ == '__main__':
     mutex_group.add_argument('--ar122_ms', action='store_true', help='use 122 archaeal marker genes')
 
     required_denovo_wf = denovo_wf_parser.add_argument_group('required named arguments')
-    required_denovo_wf.add_argument('--outgroup_taxon', required=True,
-                                help="taxon to use as outgroup (e.g., p__Patescibacteria)")
+    #required_denovo_wf.add_argument('--outgroup_taxon', required=True,
+    #                            help="taxon to use as outgroup (e.g., p__Patescibacteria)")
     required_denovo_wf.add_argument('--out_dir', required=True,
                                     help="directory to output files")
 
     optional_denovo_wf = denovo_wf_parser.add_argument_group('optional arguments')
     optional_denovo_wf.add_argument('-x', '--extension', default='fna',
                                     help='extension of files to process')
+                                    
+    optional_denovo_wf.add_argument('--skip_gtdb_refs',
+                                    action="store_true",
+                                    help='Do not include GTDB reference genomes in multiple sequence alignment.')
     optional_denovo_wf.add_argument('--taxa_filter',
-                                       help=('Filter genomes to taxa (comma separated) within '
+                                       help=('Filter GTDB genomes to taxa (comma separated) within '
                                             + 'specific taxonomic groups (e.g., d__Bacteria '
                                             + 'or p__Proteobacteria, p__Actinobacteria).'))
-    optional_denovo_wf.add_argument('--min_perc_aa', type=float, default=0,
-                                       help='filter genomes with an insufficient percentage of AA in the MSA')
+    optional_denovo_wf.add_argument('--min_perc_aa', type=float, default=10,
+                                       help='filter genomes with an insufficient percentage of AA in the MSA (inclusive bound)')
     optional_denovo_wf.add_argument('--custom_msa_filters', action="store_true",
-                                       help=('perform custom filtering of MSA with consensus '
-                                                + 'and min_perc_taxa parameters instead of using canonical mask'))
-    optional_denovo_wf.add_argument('--consensus', type=float, default=25,
-                                       help='minimum percentage of the same amino acid required to retain column')
+                                       help=('perform custom filtering of MSA with cols_per_gene, min_consensus '
+                                                + 'max_consensus, and min_perc_taxa parameters instead of using canonical mask'))
+    optional_denovo_wf.add_argument('--cols_per_gene', type=int, default=42,
+                                       help='maximum number of columns to retain per gene')
+    optional_denovo_wf.add_argument('--min_consensus', type=float, default=25,
+                                       help='minimum percentage of the same amino acid required to retain column (inclusive bound)')
+    optional_denovo_wf.add_argument('--max_consensus', type=float, default=95,
+                                       help='maximum percentage of the same amino acid required to retain column (exclusive bound)')
     optional_denovo_wf.add_argument('--min_perc_taxa', type=float, default=50,
-                                       help='minimum percentage of taxa required required to retain column')
-    optional_denovo_wf.add_argument('--prot_model', choices=['WAG', 'LG'], 
+                                       help='minimum percentage of taxa required to retain column (inclusive bound)')
+                                       
+                                       
+    optional_denovo_wf.add_argument('--prot_model', choices=['JTT', 'WAG', 'LG'], 
                                     help='protein substitution model for tree inference', default='WAG')
+    optional_denovo_wf.add_argument('--no_support', action="store_true", 
+                                    help="do not compute local support values using the Shimodaira-Hasegawa test")
+    optional_denovo_wf.add_argument('--no_gamma', action="store_true", 
+                                    help="do not rescale branch lengths to optimize the Gamma20 likelihood")
+                                    
     optional_denovo_wf.add_argument('--prefix', default='gtdbtk',
                                     help='desired prefix for output files')
     optional_denovo_wf.add_argument('--cpus', default=1, type=int,

--- a/gtdbtk/VERSION
+++ b/gtdbtk/VERSION
@@ -1,3 +1,6 @@
+0.1.6
+- align step in classify_wf function has been fixed
+- improve summary file output  
 0.1.5
 - bug fixing 
 0.1.4

--- a/gtdbtk/classify.py
+++ b/gtdbtk/classify.py
@@ -470,6 +470,8 @@ class Classify():
                         if leaf.taxon.label in unclassified_user_genomes:
                             summary_list = unclassified_user_genomes.get(
                                 leaf.taxon.label)
+                            if summary_list[12] == '':
+                                summary_list[12] = None
                         summary_list[0] = leaf.taxon.label
                         summary_list[1] = self.standardise_taxonomy(
                             red_taxonomy)

--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -200,32 +200,35 @@ class OptionsParser():
         self.logger.info(
             'Inferring tree with FastTree using %s+GAMMA.' % options.prot_model)
 
-        output_tree = os.path.join(options.out_dir, options.prefix + '.unrooted.tree')
-        tree_log = os.path.join(options.out_dir, options.prefix + '.tree.log')
-        fasttree_log = os.path.join(options.out_dir, options.prefix + '.fasttree.log')
-        
+        output_tree = os.path.join(
+            options.out_dir, options.prefix + options.suffix + '.unrooted.tree')
+        tree_log = os.path.join(
+            options.out_dir, options.prefix + options.suffix + '.tree.log')
+        fasttree_log = os.path.join(
+            options.out_dir, options.prefix + '.fasttree.log')
+
         if options.prot_model == 'JTT':
             model_str = ''
         elif options.prot_model == 'WAG':
             model_str = ' -wag'
         elif options.prot_model == 'LG':
             model_str = ' -lg'
-        
+
         support_str = ''
         if options.no_support:
             support_str = ' -nosupport'
-            
+
         gamma_str = ' -gamma'
         if options.no_gamma:
             gamma_str = ''
 
         cmd = '-quiet%s%s%s -log %s %s > %s 2> %s' % (support_str,
-                                                                model_str,
-                                                                gamma_str,
-                                                                tree_log,
-                                                                options.msa_file,
-                                                                output_tree,
-                                                                fasttree_log)
+                                                      model_str,
+                                                      gamma_str,
+                                                      tree_log,
+                                                      options.msa_file,
+                                                      output_tree,
+                                                      fasttree_log)
         if options.cpus > 1:
             cmd = 'FastTreeMP ' + cmd
         else:
@@ -323,8 +326,12 @@ class OptionsParser():
             else:
                 options.suffix = ".ar122"
 
-            options.msa_file = os.path.join(options.out_dir,
-                                            options.prefix + options.suffix + ".msa.fasta")
+            if options.skip_gtdb_refs:
+                options.msa_file = os.path.join(
+                    options.out_dir, options.prefix + options.suffix + ".user_msa.fasta")
+            else:
+                options.msa_file = os.path.join(options.out_dir,
+                                                options.prefix + options.suffix + ".msa.fasta")
             self.infer(options)
 
             options.input_tree = os.path.join(options.out_dir,
@@ -343,8 +350,11 @@ class OptionsParser():
             options.align_dir = options.out_dir
             options.taxa_filter = None
             options.custom_msa_filters = False
-            options.consensus = None
+            options.min_consensus = None
             options.min_perc_taxa = None
+            options.skip_gtdb_refs = False
+            options.cols_per_gene = None
+            options.max_consensus = None
             self.align(options)
 
             self.classify(options)

--- a/gtdbtk/markers.py
+++ b/gtdbtk/markers.py
@@ -365,20 +365,20 @@ class Markers(object):
                 ar_gids.add(gid)
 
         return bac_gids, ar_gids
-        
+
     def _write_marker_info(self, marker_db, marker_file):
         """Write out information about markers comprising MSA."""
-        
-        marker_paths = {"PFAM": os.path.join(self.pfam_hmm_dir,'individual_hmms'),
-                        "TIGRFAM": os.path.join(os.path.dirname(self.tigrfam_hmms),'individual_hmms')}
-        
+
+        marker_paths = {"PFAM": os.path.join(self.pfam_hmm_dir, 'individual_hmms'),
+                        "TIGRFAM": os.path.join(os.path.dirname(self.tigrfam_hmms), 'individual_hmms')}
+
         fout = open(marker_file, 'w')
         fout.write('Marker ID\tName\tDescription\tLength (bp)\n')
         for db_marker in sorted(marker_db):
             for marker in marker_db[db_marker]:
                 marker_id = marker[0:marker.rfind('.')]
                 marker_path = os.path.join(marker_paths[db_marker], marker)
-                
+
                 # get marker name, description, and size
                 with open(marker_path) as fp:
                     for line in fp:
@@ -390,7 +390,8 @@ class Markers(object):
                             marker_size = line.split("  ")[1].strip()
                             break
 
-                fout.write('%s\t%s\t%s\t%s\n' % (marker_id, marker_name, marker_desc, marker_size))
+                fout.write('%s\t%s\t%s\t%s\n' %
+                           (marker_id, marker_name, marker_desc, marker_size))
         fout.close()
 
     def align(self,
@@ -410,10 +411,14 @@ class Markers(object):
 
         try:
             # write out files with marker information
-            bac120_marker_info_file = os.path.join(out_dir, prefix + '.bac120.marker_info.tsv')
-            self._write_marker_info(Config.BAC120_MARKERS, bac120_marker_info_file)
-            ar122_marker_info_file =os.path.join(out_dir, prefix + '.ar122.marker_info.tsv')
-            self._write_marker_info(Config.AR122_MARKERS, ar122_marker_info_file)
+            bac120_marker_info_file = os.path.join(
+                out_dir, prefix + '.bac120.marker_info.tsv')
+            self._write_marker_info(
+                Config.BAC120_MARKERS, bac120_marker_info_file)
+            ar122_marker_info_file = os.path.join(
+                out_dir, prefix + '.ar122.marker_info.tsv')
+            self._write_marker_info(
+                Config.AR122_MARKERS, ar122_marker_info_file)
 
             genomic_files = self._path_to_identify_data(identify_dir)
             self.logger.info('Aligning markers in %d genomes with %d threads.' % (len(genomic_files),
@@ -466,30 +471,33 @@ class Markers(object):
                 # filter columns without sufficient representation across taxa
                 if custom_msa_filters:
                     aligned_genomes = merge_two_dicts(gtdb_msa, user_msa)
-                    self.logger.info('Performing custom filtering and selection of columns.')
+                    self.logger.info(
+                        'Performing custom filtering and selection of columns.')
 
                     trim_msa = TrimMSA(cols_per_gene,
-                                        min_perc_aa / 100.0,
-                                        min_consensus / 100.0,
-                                        max_consensus / 100.0,
-                                        min_per_taxa / 100.0,
-                                        os.path.join(out_dir, 'filter_%s' % marker_set_id))
+                                       min_perc_aa / 100.0,
+                                       min_consensus / 100.0,
+                                       max_consensus / 100.0,
+                                       min_per_taxa / 100.0,
+                                       os.path.join(out_dir, 'filter_%s' % marker_set_id))
 
                     trimmed_seqs, pruned_seqs = trim_msa.trim(aligned_genomes,
-                                                                    marker_info_file)
+                                                              marker_info_file)
 
                     if trimmed_seqs:
                         self.logger.info('Filtered MSA from %d to %d AAs.' % (
-                                            len(aligned_genomes.values()[0]),
-                                            len(trimmed_seqs.values()[0])))
+                            len(aligned_genomes.values()[0]),
+                            len(trimmed_seqs.values()[0])))
 
                     self.logger.info('Filtered %d genomes with amino acids in <%.1f%% of columns in filtered MSA.' % (
-                                    len(pruned_seqs),
-                                    min_perc_aa))
+                        len(pruned_seqs),
+                        min_perc_aa))
 
-                    filtered_user_genomes = set(pruned_seqs).intersection(user_msa)
+                    filtered_user_genomes = set(
+                        pruned_seqs).intersection(user_msa)
                     if len(filtered_user_genomes):
-                        self.logger.info('Filtered genomes include %d user submitted genomes.' % len(filtered_user_genomes))
+                        self.logger.info('Filtered genomes include %d user submitted genomes.' % len(
+                            filtered_user_genomes))
                 else:
                     self.logger.info(
                         'Masking columns of multiple sequence alignment using canonical mask.')
@@ -512,7 +520,8 @@ class Markers(object):
                     if len(pruned_seq) == 0:
                         perc_alignment = 0
                     else:
-                        valid_bases = sum([1 for c in pruned_seq if c.isalpha()])
+                        valid_bases = sum(
+                            [1 for c in pruned_seq if c.isalpha()])
                         perc_alignment = valid_bases * 100.0 / len(pruned_seq)
                     fout.write('%s\t%s\n' % (pruned_seq_id,
                                              'Insufficient number of amino acids in MSA (%.1f%%)' % perc_alignment))
@@ -520,13 +529,18 @@ class Markers(object):
 
                 # write out MSAs
                 if not skip_gtdb_refs:
-                    self.logger.info('Creating concatenated alignment for %d GTDB and user genomes.' % len(trimmed_seqs))
-                    msa_file = os.path.join(out_dir, prefix + ".%s.msa.fasta" % marker_set_id)
+                    self.logger.info(
+                        'Creating concatenated alignment for %d GTDB and user genomes.' % len(trimmed_seqs))
+                    msa_file = os.path.join(
+                        out_dir, prefix + ".%s.msa.fasta" % marker_set_id)
                     self._write_msa(trimmed_seqs, msa_file, gtdb_taxonomy)
 
-                trimmed_user_msa = {k: v for k, v in trimmed_seqs.iteritems() if k in user_msa}
-                self.logger.info('Creating concatenated alignment for %d user genomes.' % len(trimmed_user_msa))
-                user_msa_file = os.path.join(out_dir, prefix + ".%s.user_msa.fasta" % marker_set_id)
+                trimmed_user_msa = {
+                    k: v for k, v in trimmed_seqs.iteritems() if k in user_msa}
+                self.logger.info(
+                    'Creating concatenated alignment for %d user genomes.' % len(trimmed_user_msa))
+                user_msa_file = os.path.join(
+                    out_dir, prefix + ".%s.user_msa.fasta" % marker_set_id)
                 self._write_msa(trimmed_user_msa, user_msa_file, gtdb_taxonomy)
 
                 #==============================================================


### PR DESCRIPTION
- de_novo_wf function uses the align step so we need to add the new parameters (modifiable by users) used to trim the MSA.
- If skip_gtdb_ref is chosen for de_novo_wf, the Fasttree step will use the .user.msa.fasta file.
- classify_wf function uses the align step so we need to add default value (NON modifiable by users) to the new parameters used to trim the MSA.