### PR TITLE
Intermediate results, FastTreeMP threads, accept gzipped genomes

### DIFF
--- a/bin/gtdbtk
+++ b/bin/gtdbtk
@@ -99,7 +99,7 @@ if __name__ == '__main__':
 
     optional_denovo_wf = denovo_wf_parser.add_argument_group('optional arguments')
     optional_denovo_wf.add_argument('-x', '--extension', default='fna',
-                                    help='extension of files to process')
+                                    help='extension of files to process, gz = gzipped')
                                     
     optional_denovo_wf.add_argument('--skip_gtdb_refs',
                                     action="store_true",
@@ -158,7 +158,7 @@ if __name__ == '__main__':
 
     optional_classify_wf = classify_wf_parser.add_argument_group('optional arguments')
     optional_classify_wf.add_argument('-x', '--extension', default='fna',
-                                    help='extension of files to process')
+                                    help='extension of files to process, gz = gzipped')
     optional_classify_wf.add_argument('--min_perc_aa', type=float, default=10,
                                        help='filter genomes with an insufficient percentage of AA in the MSA')
     optional_classify_wf.add_argument('--prefix', required=False, default='gtdbtk',
@@ -191,7 +191,7 @@ if __name__ == '__main__':
 
     optional_identify = identify_parser.add_argument_group('optional arguments')
     optional_identify.add_argument('-x', '--extension', default='fna',
-                                    help='extension of files to process')
+                                    help='extension of files to process, gz = gzipped')
     optional_identify.add_argument('--prefix', default='gtdbtk',
                                     help='desired prefix for output files')
     optional_identify.add_argument('--cpus', default=1, type=int,
@@ -288,7 +288,7 @@ if __name__ == '__main__':
 
     optional_classify = classify_parser.add_argument_group('optional arguments')
     optional_classify.add_argument('-x', '--extension', default='fna',
-                                    help='extension of files to process')
+                                    help='extension of files to process, gz = gzipped')
     optional_classify.add_argument('--prefix', required=False, default='gtdbtk',
                                     help='desired prefix for output files')
     optional_classify.add_argument('--cpus', default=1, type=int,

--- a/gtdbtk/biolib_lite/prodigal_biolib.py
+++ b/gtdbtk/biolib_lite/prodigal_biolib.py
@@ -26,10 +26,11 @@ import os
 import logging
 import tempfile
 import shutil
+import subprocess
 import ntpath
 from collections import defaultdict, namedtuple
 
-from common import check_file_exists, remove_extension, make_sure_path_exists
+from common import remove_extension, make_sure_path_exists
 from seq_io import read_fasta
 from parallel import Parallel
 from execute import check_on_path
@@ -85,6 +86,9 @@ class Prodigal(object):
                 self.logger.warn('Cannot call Prodigal on an empty genome. Skipped: {}'.format(genome_file))
                 return None
 
+            # Convert the genome file into the string representation, not as an object.
+            genome_file_str = ''.join(['>%s\n%s\n' % (k, v) for k, v in seqs.items()])
+
             tmp_dir = tempfile.mkdtemp()
 
             # determine number of bases
@@ -98,14 +102,13 @@ class Prodigal(object):
             else:
                 translation_tables = [4, 11]
 
+            translation_table_gffs = dict()
             for translation_table in translation_tables:
                 os.makedirs(os.path.join(tmp_dir, str(translation_table)))
                 aa_gene_file_tmp = os.path.join(tmp_dir, str(
                     translation_table), genome_id + '_genes.faa')
                 nt_gene_file_tmp = os.path.join(tmp_dir, str(
                     translation_table), genome_id + '_genes.fna')
-                gff_file_tmp = os.path.join(tmp_dir, str(
-                    translation_table), genome_id + '.gff')
 
                 # check if there is sufficient bases to calculate prodigal
                 # parameters
@@ -114,21 +117,23 @@ class Prodigal(object):
                 else:
                     proc_str = 'single'  # estimate parameters from data
 
-                args = '-m'
+                args = ['prodigal', '-m', '-p', proc_str, '-q', '-f', 'gff', '-g', str(translation_table), '-a',
+                        aa_gene_file_tmp, '-d', nt_gene_file_tmp]
                 if self.closed_ends:
-                    args += ' -c'
+                    args.append('-c')
 
-                cmd = 'prodigal %s -p %s -q -f gff -g %d -a %s -d %s -i %s > %s 2> /dev/null' % (args,
-                                                                                                 proc_str,
-                                                                                                 translation_table,
-                                                                                                 aa_gene_file_tmp,
-                                                                                                 nt_gene_file_tmp,
-                                                                                                 genome_file,
-                                                                                                 gff_file_tmp)
-                os.system(cmd)
+                proc = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+                proc_out, proc_err = proc.communicate(input=genome_file_str)
+                gff_stdout = proc_out.decode().encode('utf-8')
+
+                translation_table_gffs[translation_table] = gff_stdout
+
+                if proc.returncode != 0:
+                    self.logger.warn('Prodigal returned a non-zero exit code while processing: {}'.format(genome_file))
+                    return None
 
                 # determine coding density
-                prodigalParser = ProdigalGeneFeatureParser(gff_file_tmp)
+                prodigalParser = ProdigalGeneFeatureParser(gff_stdout)
 
                 # Skip if no genes were called.
                 if prodigalParser.n_genes_found() == 0:
@@ -156,8 +161,8 @@ class Prodigal(object):
                 best_translation_table), genome_id + '_genes.faa'), aa_gene_file)
             shutil.copyfile(os.path.join(tmp_dir, str(
                 best_translation_table), genome_id + '_genes.fna'), nt_gene_file)
-            shutil.copyfile(os.path.join(tmp_dir, str(
-                best_translation_table), genome_id + '.gff'), gff_file)
+            with open(gff_file, 'w') as f:
+                f.write(translation_table_gffs[best_translation_table])
 
             # clean up temporary files
             shutil.rmtree(tmp_dir)
@@ -294,20 +299,18 @@ class Prodigal(object):
 class ProdigalGeneFeatureParser():
     """Parses prodigal gene feature files (GFF) output."""
 
-    def __init__(self, filename):
+    def __init__(self, file_contents):
         """Initialization.
 
         Parameters
         ----------
-        filename : str
-            GFF file to parse.
+        file_contents : str
+            The contents of the GFF file to parse.
         """
-        check_file_exists(filename)
-
         self.genes = {}
         self.last_coding_base = {}
 
-        self.__parseGFF(filename)
+        self.__parseGFF(file_contents)
 
         self.coding_base_masks = {}
         for seq_id in self.genes:
@@ -324,7 +327,7 @@ class ProdigalGeneFeatureParser():
         """
         return len(self.genes)
 
-    def __parseGFF(self, filename):
+    def __parseGFF(self, file_contents):
         """Parse genes from GFF file.
 
         Parameters
@@ -333,7 +336,7 @@ class ProdigalGeneFeatureParser():
             GFF file to parse.
         """
         bGetTranslationTable = True
-        for line in open(filename):
+        for line in file_contents.splitlines():
             if bGetTranslationTable and line.startswith('# Model Data'):
                 data_model_info = line.split(':')[1].strip().split(';')
                 dict_data_model = {}

--- a/gtdbtk/classify.py
+++ b/gtdbtk/classify.py
@@ -79,7 +79,7 @@ class Classify():
         """Place genomes into reference tree using pplacer."""
         # rename user MSA file for compatibility with pplacer
         if not user_msa_file.endswith('.fasta'):
-            t = os.path.join(out_dir, prefix + '.user_msa.fasta')
+            t = os.path.join(out_dir, Config.INTERMEDIATE_RESULTS, prefix + '.user_msa.fasta')
             shutil.copyfile(user_msa_file, t)
             user_msa_file = t
 
@@ -113,7 +113,7 @@ class Classify():
                 Config.PPLACER_DIR, Config.PPLACER_RPS23_REF_PKG)
 
         # create pplacer output directory
-        pplacer_out_dir = os.path.join(out_dir, 'pplacer')
+        pplacer_out_dir = os.path.join(out_dir, Config.INTERMEDIATE_RESULTS, 'pplacer')
         if not os.path.exists(pplacer_out_dir):
             os.makedirs(pplacer_out_dir)
 
@@ -185,7 +185,7 @@ class Classify():
         """
 
         reddictfile = open(os.path.join(
-            out_dir, prefix + '.{}.red_dictionary.tsv'.format(marker_set_id)), 'w')
+            out_dir, Config.INTERMEDIATE_RESULTS, prefix + '.{}.red_dictionary.tsv'.format(marker_set_id)), 'w')
 
         marker_dict = {}
         if marker_set_id == 'bac120':
@@ -231,7 +231,7 @@ class Classify():
 
             for marker_set_id in ('ar122', 'bac120'):
                 user_msa_file = os.path.join(
-                    align_dir, prefix + '.{}.user_msa.fasta'.format(marker_set_id))
+                    align_dir, Config.INTERMEDIATE_RESULTS, prefix + '.{}.user_msa.fasta'.format(marker_set_id))
                 if not os.path.exists(user_msa_file):
                         # file will not exist if there are no User genomes from a
                         # given domain
@@ -593,7 +593,7 @@ class Classify():
 
         """
         pplaceout = open(os.path.join(
-            out_dir, prefix + '.{}.classification_pplacer.tsv'.format(marker_set_id)), 'w')
+            out_dir, Config.INTERMEDIATE_RESULTS, prefix + '.{}.classification_pplacer.tsv'.format(marker_set_id)), 'w')
 
         # We get the pplacer taxonomy for comparison
 

--- a/gtdbtk/config/config.py
+++ b/gtdbtk/config/config.py
@@ -94,6 +94,9 @@ DEFAULT_DOMAIN_THRESHOLD = 10.0
 AR_MARKER_COUNT = 122
 BAC_MARKER_COUNT = 120
 
+# Intermediate results folder
+INTERMEDIATE_RESULTS = 'intermediate_results'
+
 # Annotation folder
 MARKER_GENE_DIR = "marker_genes"
 

--- a/gtdbtk/config/config_template.py
+++ b/gtdbtk/config/config_template.py
@@ -68,6 +68,9 @@ DEFAULT_DOMAIN_THRESHOLD = 10.0
 AR_MARKER_COUNT = 122
 BAC_MARKER_COUNT = 120
 
+# Intermediate results folder
+INTERMEDIATE_RESULTS = 'intermediate_results'
+
 # Annotation folder
 MARKER_GENE_DIR = "marker_genes"
 

--- a/gtdbtk/external/pypfam/Scan/PfamScan.py
+++ b/gtdbtk/external/pypfam/Scan/PfamScan.py
@@ -365,12 +365,15 @@ class PfamScan(object):
             else:
                 params = ['hmmsearch', '--notextw', ' '.join(hmmscan_cut_off), os.path.join(self._dir, hmmlib), self._fasta]
 
+            proc = subprocess.Popen(params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            proc_out, proc_err = proc.communicate()
+            proc_out_ascii = proc_out.decode().encode('utf-8')
 
-            run = subprocess.check_output(' '.join(params), shell=True)
+            if proc_err:
+                sys.exit('An error was encountered while running hmmsearch: %s' % proc_err)
 
             self._hmmresultIO = HMMResultsIO()
-            self._all_results = self._hmmresultIO.parseMultiHMMER3(run)
-
+            self._all_results = self._hmmresultIO.parseMultiHMMER3(proc_out_ascii)
             self._all_results = self._convert_results_search_to_scan(self._all_results)
 
             if not re_1.search(hmmlib):

--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -197,6 +197,7 @@ class OptionsParser():
 
         if options.cpus > 1:
             check_dependencies(['FastTreeMP'])
+            os.environ['OMP_NUM_THREADS'] = '%d' % options.cpus
         else:
             check_dependencies(['FastTree'])
 

--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -205,18 +205,18 @@ class OptionsParser():
 
         if hasattr(options, 'suffix'):
             output_tree = os.path.join(
-                options.out_dir, options.prefix + options.suffix + '.unrooted.tree')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + options.suffix + '.unrooted.tree')
             tree_log = os.path.join(
-                options.out_dir, options.prefix + options.suffix + '.tree.log')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + options.suffix + '.tree.log')
             fasttree_log = os.path.join(
-                options.out_dir, options.prefix + options.suffix + '.fasttree.log')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + options.suffix + '.fasttree.log')
         else:
             output_tree = os.path.join(
-                options.out_dir, options.prefix + '.unrooted.tree')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + '.unrooted.tree')
             tree_log = os.path.join(
-                options.out_dir, options.prefix + '.tree.log')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + '.tree.log')
             fasttree_log = os.path.join(
-                options.out_dir, options.prefix + '.fasttree.log')
+                options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + '.fasttree.log')
 
         if options.prot_model == 'JTT':
             model_str = ''
@@ -371,13 +371,13 @@ class OptionsParser():
 
             if options.skip_gtdb_refs:
                 options.msa_file = os.path.join(
-                    options.out_dir, options.prefix + options.suffix + ".user_msa.fasta")
+                    options.out_dir, Config.INTERMEDIATE_RESULTS, options.prefix + options.suffix + ".user_msa.fasta")
             else:
-                options.msa_file = os.path.join(options.out_dir,
+                options.msa_file = os.path.join(options.out_dir, Config.INTERMEDIATE_RESULTS,
                                                 options.prefix + options.suffix + ".msa.fasta")
             self.infer(options)
 
-            options.input_tree = os.path.join(options.out_dir,
+            options.input_tree = os.path.join(options.out_dir, Config.INTERMEDIATE_RESULTS,
                                               options.prefix + options.suffix + ".unrooted.tree")
             options.output_tree = os.path.join(options.out_dir,
                                                options.prefix + options.suffix + ".rooted.tree")

--- a/gtdbtk/markers.py
+++ b/gtdbtk/markers.py
@@ -211,7 +211,7 @@ class Markers(object):
 
             self.logger.info("Running Prodigal to identify genes.")
             self.marker_gene_dir = os.path.join(
-                out_dir, Config.MARKER_GENE_DIR)
+                out_dir, Config.INTERMEDIATE_RESULTS, Config.MARKER_GENE_DIR)
             prodigal = Prodigal(self.cpus,
                                 False,
                                 self.marker_gene_dir,
@@ -259,7 +259,7 @@ class Markers(object):
     def _path_to_identify_data(self, identity_dir):
         """Get path to genome data produced by 'identify' command."""
 
-        marker_gene_dir = os.path.join(identity_dir, Config.MARKER_GENE_DIR)
+        marker_gene_dir = os.path.join(identity_dir, Config.INTERMEDIATE_RESULTS, Config.MARKER_GENE_DIR)
 
         genomic_files = {}
         for gid in os.listdir(marker_gene_dir):
@@ -427,11 +427,11 @@ class Markers(object):
                     identify_dir, prefix + "_ar122_markers_summary.tsv"), out_dir)
             # write out files with marker information
             bac120_marker_info_file = os.path.join(
-                out_dir, prefix + '.bac120.marker_info.tsv')
+                out_dir, Config.INTERMEDIATE_RESULTS, prefix + '.bac120.marker_info.tsv')
             self._write_marker_info(
                 Config.BAC120_MARKERS, bac120_marker_info_file)
             ar122_marker_info_file = os.path.join(
-                out_dir, prefix + '.ar122.marker_info.tsv')
+                out_dir, Config.INTERMEDIATE_RESULTS, prefix + '.ar122.marker_info.tsv')
             self._write_marker_info(
                 Config.AR122_MARKERS, ar122_marker_info_file)
 
@@ -531,7 +531,7 @@ class Markers(object):
                             min_perc_aa))
 
                 # write out filtering information
-                fout = open(os.path.join(out_dir, prefix +
+                fout = open(os.path.join(out_dir, Config.INTERMEDIATE_RESULTS, prefix +
                                          ".%s.filtered.tsv" % marker_set_id), 'w')
                 for pruned_seq_id, pruned_seq in pruned_seqs.items():
                     if len(pruned_seq) == 0:
@@ -549,7 +549,7 @@ class Markers(object):
                     self.logger.info(
                         'Creating concatenated alignment for %d GTDB and user genomes.' % len(trimmed_seqs))
                     msa_file = os.path.join(
-                        out_dir, prefix + ".%s.msa.fasta" % marker_set_id)
+                        out_dir, Config.INTERMEDIATE_RESULTS, prefix + ".%s.msa.fasta" % marker_set_id)
                     self._write_msa(trimmed_seqs, msa_file, gtdb_taxonomy)
 
                 trimmed_user_msa = {
@@ -558,7 +558,7 @@ class Markers(object):
                     self.logger.info(
                         'Creating concatenated alignment for %d user genomes.' % len(trimmed_user_msa))
                     user_msa_file = os.path.join(
-                        out_dir, prefix + ".%s.user_msa.fasta" % marker_set_id)
+                        out_dir, Config.INTERMEDIATE_RESULTS, prefix + ".%s.user_msa.fasta" % marker_set_id)
                     self._write_msa(trimmed_user_msa,
                                     user_msa_file, gtdb_taxonomy)
                 else:


### PR DESCRIPTION
1. Intermediate results will be written to a subdirectory in the output root, as specified by the config file (default: intermediate_results). [Resolves #114]

2. Fixed an issue where FastTreeMP was able to use more threads than specified in the --cpus flag. Resolved by adding a temporary environment variable for OpenMP.

3. GZipped genomes are now supported, re-worked calls to Prodigal by piping FASTA file using subprocess. Prodigal gff output for the best translation table is now cached in memory and then written to disk once the best translation table is identified. No changes were made to FastANI as it supports gzipped genomes (but doesn't say so in the documentation). [Resolves #110]