### PR TITLE
Added option to use a custom taxonomy file when rooting a tree.

### DIFF
--- a/bin/gtdbtk
+++ b/bin/gtdbtk
@@ -57,7 +57,7 @@ def printHelp():
     align         -> Create multiple sequence alignment
     infer         -> Infer tree from multiple sequence alignment
     classify      -> Determine taxonomic classification of genomes
-    root          -> Root tree using an outgroup [In Development]
+    root          -> Root tree using an outgroup
     decorate      -> Decorate tree with GTDB taxonomy [In Development]
     
   Tools:
@@ -322,6 +322,8 @@ if __name__ == '__main__':
                                 help='output tree')
 
     optional_root = root_parser.add_argument_group('optional arguments')
+    optional_root.add_argument('--custom_taxonomy_file', 
+                                help="file indicating custom taxonomy string for at least the genomes belonging to the outgroup")
     optional_root.add_argument('-h', '--help', action="help",
                                 help="show help message")
                                        

--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -334,11 +334,15 @@ class OptionsParser():
 
         check_file_exists(options.input_tree)
 
-        gtdb_taxonomy = Taxonomy().read(Config.TAXONOMY_FILE)
+        if options.custom_taxonomy_file:
+            check_file_exists(options.custom_taxonomy_file)
+            taxonomy = Taxonomy().read(options.custom_taxonomy_file)
+        else:
+            taxonomy = Taxonomy().read(Config.TAXONOMY_FILE)
 
         self.logger.info('Identifying genomes from the specified outgroup.')
         outgroup = set()
-        for genome_id, taxa in gtdb_taxonomy.iteritems():
+        for genome_id, taxa in taxonomy.iteritems():
             if options.outgroup_taxon in taxa:
                 outgroup.add(genome_id)
 


### PR DESCRIPTION
This is useful if the user wished to outgroup on a set of user genomes that don't have GTDB taxonomy strings. It also applies if the user wishes to create a tree without any of the GTDB reference genomes.