### PR TITLE
refactor(Fix issue #448): Refactor code to return warning instead of …

### DIFF
--- a/gtdbtk/files/classify_summary.py
+++ b/gtdbtk/files/classify_summary.py
@@ -19,6 +19,7 @@ import logging
 import os
 from typing import Dict, List, Tuple, Optional, Union
 
+from gtdbtk.biolib_lite.common import make_sure_path_exists
 from gtdbtk.config.output import PATH_AR53_SUMMARY_OUT, PATH_BAC120_SUMMARY_OUT
 from gtdbtk.exceptions import GTDBTkExit
 
@@ -122,6 +123,7 @@ class ClassifySummaryFile:
 
     def write(self):
         """Writes the summary file to disk. None will be replaced with N/A"""
+        make_sure_path_exists(os.path.dirname(self.path))
         with open(self.path, 'w') as fh:
             fh.write('\t'.join(self.get_col_order()[0]) + '\n')
             for gid, row in sorted(self.rows.items()):


### PR DESCRIPTION
…crashing

when all the genomes are filtered out and not classified. GTDB-Tk now returns an error.