### PR TITLE
BUG: regex was malformed for 'mash info -t ...' output

### DIFF
--- a/gtdbtk/external/mash.py
+++ b/gtdbtk/external/mash.py
@@ -211,7 +211,7 @@ class SketchFile(object):
             raise GTDBTkExit(f'Error reading Mash sketch file {self.path}:\n{stderr}')
 
         for hashes, length, path in re.findall(r'(\d+)\t(\d+)\t(.+).*\n', stdout):
-            self.data[path] = (int(hashes), int(length))
+            self.data[path.strip()] = (int(hashes), int(length))
 
     def _is_consistent(self):
         """Returns True if the sketch was generated from the genomes."""

--- a/gtdbtk/external/mash.py
+++ b/gtdbtk/external/mash.py
@@ -210,7 +210,7 @@ class SketchFile(object):
         if proc.returncode != 0:
             raise GTDBTkExit(f'Error reading Mash sketch file {self.path}:\n{stderr}')
 
-        for hashes, length, path in re.findall(r'^(\d+)\t(\d+)\t(.+).*\n', stdout):
+        for hashes, length, path in re.findall(r'(\d+)\t(\d+)\t(.+).*\n', stdout):
             self.data[path] = (int(hashes), int(length))
 
     def _is_consistent(self):

--- a/gtdbtk/external/mash.py
+++ b/gtdbtk/external/mash.py
@@ -210,7 +210,7 @@ class SketchFile(object):
         if proc.returncode != 0:
             raise GTDBTkExit(f'Error reading Mash sketch file {self.path}:\n{stderr}')
 
-        for hashes, length, path in re.findall(r'(\d+)\t(\d+)\t(.+)\t.+\n', stdout):
+        for hashes, length, path in re.findall(r'^(\d+)\t(\d+)\t(.+).*\n', stdout):
             self.data[path] = (int(hashes), int(length))
 
     def _is_consistent(self):


### PR DESCRIPTION
The `SketchFile._load_metadata()` method was using a malformed regex. The fix removes a case that doesn't seem to be presented by mash. A `strip` is performed as the last group may or may not get a `\t` -- that can probably be covered in the regex as well but this doesn't seem like a performance critical block.

An example of the difference is shown below. This issue was observed on the GTDB-tk 2.3.0 release using Mash 1.1.

```python
>>> example_mashline = '5000\t6722799\t/gtdbtk-data/release214/fastani/database/GCF/945/605/565\t\n'

#  the original regex does not match
>>> re.compile(r'(\d+)\t(\d+)\t(.+)\t.+\n').match(example_mashline)

# the modified line does capture
>>> re.compile(r'(\d+)\t(\d+)\t(.+).*\n').match(example_mashline)
<re.Match object; span=(0, 71), match='5000\t6722799\t/gtdbtk-data/release214/fastani/da>
>>>
```