### PR TITLE
fix(setup.py): use ~= to constrain major version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             'gtdbtk = gtdbtk.__main__:main'
         ]
     },
-    install_requires=["dendropy>=4.1.0", 'numpy>=1.9.0', 'tqdm>=4.35.0', 'pydantic>=1.9.2,<2.0a1'],
+    install_requires=["dendropy~=4.1.0", 'numpy~=1.9.0', 'tqdm~=4.35.0', 'pydantic~=1.9.2'],
     license=meta['license'],
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
package ~= x.y.z is the same as (package >= x.y.z, package == x.*). This prevents the wrong numpy version (2.x) from being installed, such as in #467 (which is not yet properly fixed and should NOT have been closed).

See: https://peps.python.org/pep-0440/#compatible-release