### PR TITLE
fix(fixing of issue #573):

### DIFF
--- a/gtdbtk/ani_screen.py
+++ b/gtdbtk/ani_screen.py
@@ -14,7 +14,7 @@ from gtdbtk.config.common import CONFIG
 class ANIScreener(object):
     """Computes a list of genomes to a list of representatives."""
 
-    def __init__(self, cpus):
+    def __init__(self, cpus,af_threshold=None):
         """Instantiate the ANI rep class.
 
         Parameters
@@ -24,6 +24,7 @@ class ANIScreener(object):
         """
         self.logger = logging.getLogger('timestamp')
         self.cpus = cpus
+        self.af_threshold = af_threshold if af_threshold else CONFIG.AF_THRESHOLD
         self.gtdb_radii = GTDBRadiiFile()
 
     def run_aniscreen(self,genomes, no_mash,out_dir,prefix, mash_k, mash_v, mash_s, mash_max_dist, mash_db):
@@ -87,7 +88,7 @@ class ANIScreener(object):
         # sort the dictionary by ani then af
         for gid in skani_results.keys():
             thresh_results = [(ref_gid, hit) for (ref_gid, hit) in skani_results[gid].items() if
-                              hit['af'] >= CONFIG.AF_THRESHOLD and hit['ani'] >= self.gtdb_radii.get_rep_ani(
+                              hit['af'] >= self.af_threshold and hit['ani'] >= self.gtdb_radii.get_rep_ani(
                                   canonical_gid(ref_gid))]
             all_results = [(ref_gid, hit) for (ref_gid, hit) in skani_results[gid].items()]
             closest = sorted(thresh_results, key=lambda x: (-x[1]['ani'], -x[1]['af']))

--- a/gtdbtk/files/classify_summary.py
+++ b/gtdbtk/files/classify_summary.py
@@ -107,6 +107,16 @@ class ClassifySummaryFile:
             raise GTDBTkExit(f'Attempting to add duplicate row: {row.gid}')
         self.rows[row.gid] = row
 
+    def get_row(self, gid: str) -> ClassifySummaryFileRow:
+        if gid not in self.rows:
+            raise GTDBTkExit(f'Attempting to get non-existent row: {gid}')
+        return self.rows[gid]
+
+    def update_row(self, row: ClassifySummaryFileRow):
+        if row.gid not in self.rows:
+            raise GTDBTkExit(f'Attempting to update non-existent row: {row.gid}')
+        self.rows[row.gid] = row
+
     def has_row(self) -> bool:
         if self.rows.items():
             return True

--- a/gtdbtk/files/stage_logger.py
+++ b/gtdbtk/files/stage_logger.py
@@ -29,6 +29,7 @@ class ANIScreenStep(Steps):
     mash_s: Optional[str]
     mash_v: Optional[str]
     mash_max_dist: Optional[str]
+    min_af: Optional[str]
     mash_db: Optional[str]
     output_files: Optional[Dict]
 

--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -641,6 +641,7 @@ class OptionsParser(object):
         ani_step.mash_k = options.mash_k
         ani_step.mash_v = options.mash_v
         ani_step.mash_s = options.mash_s
+        ani_step.min_af = options.min_af
         ani_step.mash_max_dist = options.mash_max_distance
 
         if options.genome_dir:
@@ -664,7 +665,7 @@ class OptionsParser(object):
                                               options.batchfile,
                                               options.extension)
 
-        aniscreener = ANIScreener(options.cpus)
+        aniscreener = ANIScreener(options.cpus,options.min_af)
         classified_genomes,reports = aniscreener.run_aniscreen(
             genomes=genomes,
             no_mash=options.no_mash,


### PR DESCRIPTION
In some cases, when running the 3 classify steps independently, a genome may be filtered out in the alignment step. However, it's still present in the ani screening from the classify step and can have a ANI > 95% ( this can happen with partial genomes, where AF can still be high) Tk would try to report it twice in the summary file and would return an error. Instead we report it as classified with ani,
 but with a warning from the alignment step ( MSA < 10%).
 skani should reduce the number of such cases as it keep AF low for partial genomes.