### PR TITLE
Replace deprecated tostring() with tobytes() for NumPy compatibility

### DIFF
--- a/gtdbtk/markers.py
+++ b/gtdbtk/markers.py
@@ -363,7 +363,7 @@ class Markers(object):
             for aa_char, aa_count in zip(masked_seq_unique[0], masked_seq_unique[1]):
                 masked_seq_counts[aa_char.decode('utf-8')] = aa_count
 
-            masked_seq = list_masked_seq.tostring().decode('utf-8')
+            masked_seq = list_masked_seq.tobytes().decode('utf-8')
 
             valid_bases = list_masked_seq.shape[0] - \
                 masked_seq_counts['.'] - masked_seq_counts['-']


### PR DESCRIPTION
Issue:
Using `GTDB-Tk v2.4.1` got the error `gtdbtk AttributeError: 'numpy.ndarray' object has no attribute 'tostring'`


Solution:
The tostring() method has been deprecated in NumPy since version 1.19 and removed in NumPy 2.0. The recommended replacement is tobytes(), which provides identical functionality. 

[NumPy 1.19 Release Notes: tostring() deprecated](https://numpy.org/devdocs/release/1.19.0-notes.html#deprecations)
[NumPy tobytes() Documentation](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html)